### PR TITLE
Oppgraderer Distroless til nodejs20-debian12@sha256:6fe218db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12@sha256:8ce2935455d9c9c8ea04d53ea42c30bfba5ceffbf580fd796217f35c00d6d11c
+FROM gcr.io/distroless/nodejs20-debian12@sha256:6fe218dbad37e979c7542e670d28d6e23d3f53d2929693bc9cdded8b622f339f
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Fra flex-cli