### PR TITLE
Gi grafene litt mer plass

### DIFF
--- a/src/components/Arkitektur.tsx
+++ b/src/components/Arkitektur.tsx
@@ -142,7 +142,7 @@ export const Arkitektur = (): ReactElement => {
                 />
             )}
             {!fullscreen && (
-                <div className="h-46 px-10 py-5">
+                <div className="h-46 px-10 py-5 pb-0">
                     <div className="flex gap-3">
                         <RadioGroup
                             legend="Søkemetode"

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -206,7 +206,7 @@ export function Graph({
         if (fullscreen) {
             return '100vh'
         }
-        return 'calc(100vh - 28vh)'
+        return 'calc(100vh - 15vh)'
     }
 
     return (

--- a/src/components/RapidGraph.tsx
+++ b/src/components/RapidGraph.tsx
@@ -152,7 +152,7 @@ export function RapidGraph({
         if (fullscreen) {
             return '100vh'
         }
-        return 'calc(100vh - 28vh)'
+        return 'calc(100vh - 15vh)'
     }
 
     return (

--- a/src/components/TbdRapid.tsx
+++ b/src/components/TbdRapid.tsx
@@ -113,7 +113,7 @@ export const TbdRapid = (): ReactElement => {
                 />
             )}
             {!fullscreen && (
-                <div className="h-46 px-10 py-5">
+                <div className="h-46 px-10 py-5 pb-0">
                     <div className="flex gap-3">
                         <RadioGroup
                             legend="Søkemetode"


### PR DESCRIPTION
Jeg syntes det var litt irriterende at grafen ble kuttet en del nederst i skjermbildet, så jeg ga den litt mer å gå på. Fjernet også padding under "verktøyboksen," fikk det ikke til å virke med å sette `pt-5` så da ble det å legge til `pb-5` i stedet.

<img width="1612" height="1566" alt="image" src="https://github.com/user-attachments/assets/2eab3bec-a197-48fa-bb32-3bf40dfb08b9" />
